### PR TITLE
Fix Dockerfile and build procedure.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2020.02-Linux-x86_6
 RUN . /opt/anaconda3/etc/profile.d/conda.sh && conda activate base && \
     git clone --recursive https://github.com/scikit-hep/awkward-1.0.git /opt/awkward-1.0 && \ 
     cd /opt/awkward-1.0 && \
-    python setup.py install --user
+    pip install .
 
 RUN cd ~ && \
     git clone https://github.com/det-lab/dataReaderWriter.git && \

--- a/kaitai/awkward_example/CMakeLists.txt
+++ b/kaitai/awkward_example/CMakeLists.txt
@@ -5,14 +5,17 @@ PROJECT(kaitaiAnimalReader)
 set(CMake_Misc_Dir "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMake_Misc_Dir}")
 
+execute_process(COMMAND python -m awkward1.config --incdir OUTPUT_VARIABLE AWKWARD_INCLUDE OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process(COMMAND python -m awkward1.config --libdir OUTPUT_VARIABLE AWKWARD_LIBRARIES OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 include_directories(${CMAKE_PREFIX_PATH}/include)
 
 include(Hardening)
 include(FetchContent)
 include(DownloadCLI11)
 
-find_library(CPU-KERNELS awkward-cpu-kernels HINTS ${CMAKE_PREFIX_PATH}/lib)
-find_library(LIBAWKWARD awkward HINTS ${CMAKE_PREFIX_PATH}/lib)
+find_library(CPU-KERNELS awkward-cpu-kernels REQUIRED HINTS ${AWKWARD_LIBRARIES})
+find_library(LIBAWKWARD awkward REQUIRED HINTS ${AWKWARD_LIBRARIES})
 message(STATUS "Libraries: ${LIBAWKWARD} ${CPU-KERNELS}")
 
 downloadCLI11IfNeeded("CLI11")
@@ -36,7 +39,7 @@ add_subdirectory("${kaitai_struct_cpp_runtime_DIR}")
 
 add_executable(kaitaiAnimalReader "${SRCFILES}")
 target_link_libraries(kaitaiAnimalReader kaitai_struct_cpp_stl_runtime ${CPU-KERNELS} ${LIBAWKWARD})
-target_include_directories(kaitaiAnimalReader  PUBLIC "${kaitai_struct_cpp_runtime_DIR}" "${CLI11_INCLUDE_DIR}")
+target_include_directories(kaitaiAnimalReader  PUBLIC "${kaitai_struct_cpp_runtime_DIR}" "${CLI11_INCLUDE_DIR}" "${AWKWARD_INCLUDE}")
 
 set_target_properties(kaitaiAnimalReader PROPERTIES CXX_VISIBILITY_PRESET hidden)
 #target_link_libraries(kaitaiAnimalReader PRIVATE ${CPU-KERNELS} ${LIBAWKWARD})


### PR DESCRIPTION
I started by taking a look at your build and I saw a few things to fix, but it also reminded me that we had a complaint that the Awkward deployment procedure, as it stands, raises an issue with Homebrew on MacOS (scikit-hep/awkward-1.0#411). So before I could give you any advice on how to fix this, I had to fix the Awkward build procedure so that it wouldn't be changing under you.

That was PR scikit-hep/awkward-1.0#439. What's new is that all of the include files and libraries are now strictly inside of the Python package, not installed in the standard locations (`/usr/lib`, `/usr/include`, etc. because Homebrew didn't expect anything there that it wasn't managing itself).

Part of that meant that I'd be introducing a tool to tell you where to find those now non-standard files:

```bash
$ python -m awkward1.config --cflags --libs
-std=c++11 -I/path/to/awkward1/include -L/path/to/awkward1 -lawkward -lawkward-cpu-kernels
```

If Awkward is installed as a Python library, this command will work, and it tells you where the includes and libraries are.

I updated the [dependent-project documentation](https://github.com/scikit-hep/awkward-1.0/tree/master/dependent-project), which is where you got your CMakeLists.txt file from, originally. Now we do an `execute_process` [inside the CMakeLists.txt](https://github.com/scikit-hep/awkward-1.0/blob/master/dependent-project/CMakeLists.txt) to set `AWKWARD_INCLUDE` and `AWKWARD_LIBRARIES` variables.

With these additions, your CMake configures and builds. The executable segfaults, but I think that's a different issue. (As in dependent-project, you'll need to choose whether to use static libraries or get the shared libraries onto your system's library search path. That wasn't the issue with the segfault, though.)

I also noticed that in making your Docker image, you used `python setup.py install --user` to install the package. `python setup.py install` and `--user` are both deprecated, and using this method puts the package in a strange place; your user's `~/.local` directory, which I guess is `root` because this is a Docker image. The purpose of `--user` and `~/.local` was to be able to install Python packages when you don't have root access, but you do because it's a Docker image. Also, you're installing it with Anaconda, with is _another_ way of getting permission to install without `--user` (because pip without `--user` goes into the Anaconda directory, which is under user control, not root). Since there were three independent reasons not to use `python setup.py install --user`, I swapped it for

```bash
pip install .
```

which is what people recommend over `python setup.py install` these days (with or without `--user`). The difference is that `pip install .` does some bookkeeping more cleanly.

That's it! I think you should be able to proceed now—good luck!